### PR TITLE
feat: add molecules info to python

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -101,7 +101,6 @@ std::vector<std::tuple<std::string, std::vector<std::string>>> get_sutaible_meth
 
 std::map<std::string, std::vector<double>>
 calculate_charges(struct Molecules &molecules, const std::string &method_name, std::optional<const std::string> &parameters_name) {
-
     std::string method_file = fs::path(INSTALL_DIR) / "lib" / ("lib" + method_name + ".so");
     auto handle = dlopen(method_file.c_str(), RTLD_LAZY);
 
@@ -161,5 +160,5 @@ PYBIND11_MODULE(chargefw2, m) {
           "Return the list of all parameters of a given method");
     m.def("get_suitable_methods", &get_sutaible_methods_python, "molecules"_a, "Get methods and parameters that are suitable for a given set of molecules");
     m.def("calculate_charges", &calculate_charges, "molecules"_a, "method_name"_a, py::arg("parameters_name") = py::none(),
-          "Calculate partial atomic charges for a given molecules and method");
+          "Calculate partial atomic charges for a given molecules and method", py::call_guard<py::gil_scoped_release>());
 }

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -33,8 +33,6 @@ std::vector<std::tuple<std::string, std::vector<std::string>>> get_sutaible_meth
 struct MoleculeInfo {
     struct AtomTypeCount {
         std::string symbol;
-        std::string cls;
-        std::string type;
         int count;
 
         [[nodiscard]] py::dict to_dict() const;
@@ -63,8 +61,6 @@ py::dict MoleculeInfo::to_dict() const {
 py::dict MoleculeInfo::AtomTypeCount::to_dict() const {
         return py::dict(
             py::arg("symbol") = symbol,
-            py::arg("cls") = cls,
-            py::arg("type") = type,
             py::arg("count") = count
     );
 }
@@ -139,12 +135,10 @@ MoleculeInfo Molecules::info() {
 
     if (atom_types.size() > 0) {
         for (auto &[key, val] : counts) {
-            auto [symbol, cls, type] = atom_types[key];
+            auto symbol =  std::get<0>(atom_types[key]);
             
             result.atom_type_counts.push_back({
                 .symbol = symbol,
-                .cls = cls,
-                .type = type,
                 .count = val
             });
         }
@@ -228,8 +222,6 @@ PYBIND11_MODULE(chargefw2, m) {
     py::class_<MoleculeInfo::AtomTypeCount>(m, "AtomTypeCount")
         .def(py::init<>())
         .def_readwrite("symbol", &MoleculeInfo::AtomTypeCount::symbol)
-        .def_readwrite("cls", &MoleculeInfo::AtomTypeCount::cls)
-        .def_readwrite("type", &MoleculeInfo::AtomTypeCount::type)
         .def_readwrite("count", &MoleculeInfo::AtomTypeCount::count)
         .def("to_dict", &MoleculeInfo::AtomTypeCount::to_dict);
 

--- a/src/structures/molecule_set.cpp
+++ b/src/structures/molecule_set.cpp
@@ -31,11 +31,23 @@ MoleculeSet::MoleculeSet(std::unique_ptr<std::vector<Molecule> > molecules) : mo
     }
 }
 
-
 void MoleculeSet::info() const {
-    fmt::print("Number of molecules: {}\n", molecules_->size());
+    auto stats = get_stats();
+
+    fmt::print("Number of molecules: {}\n", stats.total_molecules);
+    fmt::print("Number of atoms: {}\n", stats.total_atoms);
+    
+    for (auto &atom_type_count: stats.atom_type_counts) {
+        auto[symbol, cls, type, count] = atom_type_count;
+        fmt::print("{:2s} {:6s} {:4s}: {}\n", symbol, cls, type, count);
+    }
+}
+
+MoleculeSetStats MoleculeSet::get_stats() const {
+    MoleculeSetStats result;
     std::map<size_t, int> counts;
     size_t n_atoms = 0;
+
     for (const auto &m: *molecules_) {
         for (auto &a : m.atoms()) {
             counts[a.type()] += 1;
@@ -43,11 +55,23 @@ void MoleculeSet::info() const {
         }
     }
 
-    fmt::print("Number of atoms: {}\n", n_atoms);
-    for (auto &[key, val]: counts) {
-        auto[symbol, cls, type] = atom_types_[key];
-        fmt::print("{:2s} {:6s} {:4s}: {}\n", symbol, cls, type, val);
+    result.total_molecules = molecules_->size();
+    result.total_atoms = n_atoms;
+
+    if (atom_types_.size() > 0) {
+        for (auto &[key, val] : counts) {
+            auto [symbol, cls, type] =  atom_types_[key];
+            
+            result.atom_type_counts.push_back({
+                .symbol = symbol,
+                .cls = cls,
+                .type = type,
+                .count = val
+            });
+        }
     }
+    
+    return result;
 }
 
 

--- a/src/structures/molecule_set.h
+++ b/src/structures/molecule_set.h
@@ -42,6 +42,18 @@ struct deduce_from<Bond>
     typedef bond_t AB_t;
 };
 
+struct MoleculeSetStats {
+    struct AtomTypeCount {
+        std::string symbol;
+        std::string cls;
+        std::string type;
+        int count;
+    };
+
+    size_t total_molecules;
+    size_t total_atoms;
+    std::vector<AtomTypeCount> atom_type_counts;
+};
 
 class MoleculeSet {
     std::vector<atom_t> atom_types_{};
@@ -62,6 +74,8 @@ public:
     explicit MoleculeSet(std::unique_ptr<std::vector<Molecule> > molecules);
 
     void info() const;
+
+    MoleculeSetStats get_stats() const;
 
     [[nodiscard]] const std::vector<Molecule> &molecules() const { return *molecules_; }
 


### PR DESCRIPTION
Adds `Molecules::info` to python bindings.

**Usage**
Properties can be accessed directly:
```py
molecules = Molecules("/path/to/file")
info = molecules.info()
print(info.total_atoms) # 29874
```
Or the result can be converted to a `dict` that can be serialized:
```py
info.to_dict()
```

**Example output (receptor.pdb from acc2 examples)**
```json
{
    "total_molecules": 1,
    "total_atoms": 29874,
    "atom_type_counts": [
      {
        "symbol": "N",
        "count": 2386
      },
      {
        "symbol": "C",
        "count": 9738
      },
      {
        "symbol": "O",
        "count": 2723
      },
      {
        "symbol": "H",
        "count": 14950
      },
      {
        "symbol": "S",
        "count": 77
      }
    ]
}
```