### PR TITLE
feat: fulfill only necessary requirements in python

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -13,7 +13,6 @@
 #include "candidates.h"
 #include "utility/strings.h"
 
-
 namespace fs = std::filesystem;
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -45,8 +44,6 @@ Molecules::Molecules(const std::string &filename, bool read_hetatm = true, bool 
     if (ms.molecules().empty()) {
         throw std::runtime_error("No molecules were loaded from the input file");
     }
-
-    ms.fulfill_requirements({RequiredFeatures::DISTANCE_TREE, RequiredFeatures::BOND_DISTANCES});
 }
 
 
@@ -111,6 +108,9 @@ calculate_charges(struct Molecules &molecules, const std::string &method_name, s
     }
 
     auto method = (*get_method_handle)();
+
+    molecules.ms.fulfill_requirements(method->get_requirements());
+
     std::unique_ptr<Parameters> parameters;
     if (method->has_parameters()) {
         if (!parameters_name.has_value()) {


### PR DESCRIPTION
Moved `fulfill_requirements` call from `Molecules` constructor into `calculate_charges` method so only requirements required by the used method are being fulfilled.